### PR TITLE
Fix Unable to cast object of type 'LXProtocols.TCNet.Packets.TCNetOptOut

### DIFF
--- a/LXProtocols.TCNet/TCNetPacketBuilder.cs
+++ b/LXProtocols.TCNet/TCNetPacketBuilder.cs
@@ -54,7 +54,7 @@ namespace LXProtocols.TCNet
         static TCNetPacketBuilder()
         {
             TCNetPacketBuilder.RegisterPacket(MessageTypes.OptIn, (() => new TCNetOptIn()));
-            TCNetPacketBuilder.RegisterPacket(MessageTypes.OptIn, (() => new TCNetOptOut()));
+            TCNetPacketBuilder.RegisterPacket(MessageTypes.OptOut, (() => new TCNetOptOut()));
             TCNetPacketBuilder.RegisterPacket(MessageTypes.TimeSync, (() => new TCNetTimeSync()));
             TCNetPacketBuilder.RegisterPacket(MessageTypes.Error, (() => new TCNetError()));
             TCNetPacketBuilder.RegisterPacket(MessageTypes.DataRequest, (() => new TCNetDataRequest()));


### PR DESCRIPTION
Fix exception "Unable to cast object of type 'LXProtocols.TCNet.Packets.TCNetOptOut' to type 'LXProtocols.TCNet.Packets.TCNetOptIn'." caused by incorrect registration of packet builder