### PR TITLE
SLP: Add option to disable binding to well-known port

### DIFF
--- a/Acn/Helpers/SlpDeviceManager.cs
+++ b/Acn/Helpers/SlpDeviceManager.cs
@@ -179,6 +179,16 @@ namespace Acn.Helpers
         /// </value>
         public bool Running { get; private set; }
 
+        /// <summary>
+        /// Whether the well-known SLP port should be bound to receive SLP datagrams; this is usually
+        /// used to join SLP multicast groups. Note that the well-known port is normally port 427,
+        /// which requires elevated privileges to bind in some environments.
+        ///
+        /// Takes effect when the SLP sockets are next opened, either during a call to
+        /// <see cref="Start" /> or <see cref="RefreshAgents" />.
+        /// </summary>
+        public bool OpenWellKnownPort { get; set; } = true;
+
         #endregion
 
         #region Public interface
@@ -194,10 +204,9 @@ namespace Acn.Helpers
             lock (agents)
             {
                 foreach (var agent in agents.Keys)
-                {
-                    agent.Open();
-                }
+                    agent.Open(OpenWellKnownPort);
             }
+
             UpdateDevices();
             RequestPollCallback();
         }
@@ -209,7 +218,6 @@ namespace Acn.Helpers
         {
             UpdateDevices();
         }
-
 
         /// <summary>
         /// Stops polling.
@@ -238,7 +246,7 @@ namespace Acn.Helpers
                 {
                     //If we are running start the agents.
                     foreach (var agent in agents.Keys)
-                        agent.Open();
+                        agent.Open(OpenWellKnownPort);
                 }
             }
         }

--- a/Acn/Slp/SlpAgent.cs
+++ b/Acn/Slp/SlpAgent.cs
@@ -94,7 +94,15 @@ namespace Acn.Slp
 
         #region Agent
 
-        public virtual void Open()
+        /// <summary>
+        /// Opens a unicast socket bound to any local port on <see cref="NetworkAdapter"/> for
+        /// sending and receiving SLP datagrams, and optionally also opens a socket listening to
+        /// the SLP well-known port (<see cref="SlpSocket.Port"/>) to receive multicast SLP
+        /// datagrams.
+        /// </summary>
+        /// <param name="openWellKnownPort">Whether the socket listening on the well-known port
+        /// should be opened or not.</param>
+        public virtual void Open(bool openWellKnownPort)
         {
             //Open the socket on any available port, this will be used for all unicast communication. 
             //Using an assigned port rather than 427 ensures we are discoverable on a system running multiple SLP clients.
@@ -108,7 +116,7 @@ namespace Acn.Slp
 
             //Open a socket to listen to multicast traffic on port 427, this socket is only used to listen for multicast traffic.
             //As unicast traffic is not able to share port 427 we only use this socket to recieve multicast.
-            if(multicastListenSocket == null)
+            if (openWellKnownPort && multicastListenSocket is null)
             {
                 multicastListenSocket = new SlpSocket();
                 multicastListenSocket.NewPacket += new EventHandler<NewPacketEventArgs>(socket_NewPacket);

--- a/Acn/Slp/SlpServiceAgent.cs
+++ b/Acn/Slp/SlpServiceAgent.cs
@@ -218,7 +218,17 @@ namespace Acn.Slp
 
         #region Service Agent
 
-        public override void Open()
+        /// <summary>
+        /// Opens a unicast socket bound to any local port on <see cref="NetworkAdapter"/> for
+        /// sending and receiving SLP datagrams, and optionally also opens a socket listening to
+        /// the SLP well-known port (<see cref="SlpSocket.Port"/>) to receive multicast SLP
+        /// datagrams.
+        ///
+        /// Additionally, sends a service request for available discovery agents.
+        /// </summary>
+        /// <param name="openWellKnownPort">Whether the socket listening on the well-known port
+        /// should be opened or not.</param>
+        public override void Open(bool openWellKnownPort)
         {
             if (Active)
                 throw new InvalidOperationException("The service agent is already active. Either close this agent or do not call Open while active.");
@@ -232,7 +242,7 @@ namespace Acn.Slp
             if (string.IsNullOrEmpty(ServiceUrl))
                 throw new InvalidOperationException("An attempt was made to open the service without setting the ServiceUrl first.");
 
-            base.Open();
+            base.Open(openWellKnownPort);
 
             SendDARequest();
         }

--- a/Acn/Slp/SlpUserAgent.cs
+++ b/Acn/Slp/SlpUserAgent.cs
@@ -64,9 +64,19 @@ namespace Acn.Slp
 
         #region User Agent
 
-        public override void Open()
+        /// <summary>
+        /// Opens a unicast socket bound to any local port on <see cref="NetworkAdapter"/> for
+        /// sending and receiving SLP datagrams, and optionally also opens a socket listening to
+        /// the SLP well-known port (<see cref="SlpSocket.Port"/>) to receive multicast SLP
+        /// datagrams.
+        ///
+        /// Additionally, sends a service request for available discovery agents.
+        /// </summary>
+        /// <param name="openWellKnownPort">Whether the socket listening on the well-known port
+        /// should be opened or not.</param>
+        public override void Open(bool openWellKnownPort)
         {
-            base.Open();
+            base.Open(openWellKnownPort);
 
             //Discover any DA's we should be talking to.
             SendDARequest();

--- a/ProductVersion.cs
+++ b/ProductVersion.cs
@@ -9,6 +9,6 @@ using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
-[assembly: AssemblyVersion("2.0.11.0")]
-[assembly: AssemblyFileVersion("2.0.11.0")]
+[assembly: AssemblyVersion("2.0.12.0")]
+[assembly: AssemblyFileVersion("2.0.12.0")]
 

--- a/Samples/AcnDataMatrix/RdmNetEndPointExplorer.cs
+++ b/Samples/AcnDataMatrix/RdmNetEndPointExplorer.cs
@@ -50,7 +50,7 @@ namespace AcnDataMatrix
                 acnSocket.Open(new IPEndPoint(LocalAdapter, 0));
             }
 
-            slpUser.Open();
+            slpUser.Open(openWellKnownPort: true);
             slpUser.Find("service:rdmnet-device");
         }
 

--- a/Samples/SandboxAcnDevice/AcnDevice.cs
+++ b/Samples/SandboxAcnDevice/AcnDevice.cs
@@ -86,7 +86,7 @@ namespace SandboxAcnDevice
                 slpService.Attributes["Knowledge"] = "Power";
                 slpService.Attributes["Tea"] = "Happiness";
 
-                slpService.Open();
+                slpService.Open(openWellKnownPort: true);
             }       
         }
 

--- a/Samples/SlpDiscovery/SlpDiscovery.cs
+++ b/Samples/SlpDiscovery/SlpDiscovery.cs
@@ -33,7 +33,7 @@ namespace SlpDiscovery
 
             //slpUser.NetworkAdapter = new IPAddress(new byte[] { 10, 0, 0, 1 });
             slpUser.Scope = scopeSelect.Text;
-            slpUser.Open();
+            slpUser.Open(openWellKnownPort: true);
             slpUser.Find(urlText.Text);
         }
 


### PR DESCRIPTION
In commit 4985722c, changes were made to cause the SLP socket to be
bound to an ephemeral local port to enable multiple SLP sockets to
co-exist.

As part of this change, all SLP sockets gained functionality causing
them to *also* bind to the SLP well-known port for the purposes of
receiving multicasts, which previously would not have happened for
sockets created by agent implementations of type `SlpUserAgent`.

This causes issues in environments (such as Linux) where binding to
well-known port numbers is a privileged operation, meaning that starting
the `SlpDeviceManager` on these platforms as a non-privileged user would
cause `SocketExceptions` to be thrown.

This commit adds a property to the `SlpDeviceManager` which allows
callers to disable opening of the well-known port.