### PR TITLE
SLP: Ensure multicast group is always joined

### DIFF
--- a/Acn/Helpers/SlpDeviceManager.cs
+++ b/Acn/Helpers/SlpDeviceManager.cs
@@ -184,6 +184,8 @@ namespace Acn.Helpers
         /// used to join SLP multicast groups. Note that the well-known port is normally port 427,
         /// which requires elevated privileges to bind in some environments.
         ///
+        /// If false, the ephemeral port will join the multicast group instead.
+        ///
         /// Takes effect when the SLP sockets are next opened, either during a call to
         /// <see cref="Start" /> or <see cref="RefreshAgents" />.
         /// </summary>

--- a/Acn/Slp/SlpAgent.cs
+++ b/Acn/Slp/SlpAgent.cs
@@ -101,7 +101,8 @@ namespace Acn.Slp
         /// datagrams.
         /// </summary>
         /// <param name="openWellKnownPort">Whether the socket listening on the well-known port
-        /// should be opened or not.</param>
+        /// should be opened or not. If false, the ephemeral port will join the multicast group
+        /// instead.</param>
         public virtual void Open(bool openWellKnownPort)
         {
             //Open the socket on any available port, this will be used for all unicast communication. 
@@ -111,7 +112,9 @@ namespace Acn.Slp
                 socket = new SlpSocket();
                 socket.NewPacket += new EventHandler<NewPacketEventArgs>(socket_NewPacket);
 
-                socket.Open(new IPEndPoint(NetworkAdapter,0),false);
+                /* If we won't be opening the well known port to join the multicast group, we should
+                 * join the multicast group with this port instead so that we do receive multicast traffic. */
+                socket.Open(new IPEndPoint(NetworkAdapter, port: 0), !openWellKnownPort);
             }
 
             //Open a socket to listen to multicast traffic on port 427, this socket is only used to listen for multicast traffic.

--- a/Acn/Slp/SlpServiceAgent.cs
+++ b/Acn/Slp/SlpServiceAgent.cs
@@ -227,7 +227,8 @@ namespace Acn.Slp
         /// Additionally, sends a service request for available discovery agents.
         /// </summary>
         /// <param name="openWellKnownPort">Whether the socket listening on the well-known port
-        /// should be opened or not.</param>
+        /// should be opened or not. If false, the ephemeral port will join the multicast group
+        /// instead.</param>
         public override void Open(bool openWellKnownPort)
         {
             if (Active)

--- a/Acn/Slp/SlpUserAgent.cs
+++ b/Acn/Slp/SlpUserAgent.cs
@@ -73,7 +73,8 @@ namespace Acn.Slp
         /// Additionally, sends a service request for available discovery agents.
         /// </summary>
         /// <param name="openWellKnownPort">Whether the socket listening on the well-known port
-        /// should be opened or not.</param>
+        /// should be opened or not. If false, the ephemeral port will join the multicast group
+        /// instead.</param>
         public override void Open(bool openWellKnownPort)
         {
             base.Open(openWellKnownPort);


### PR DESCRIPTION
For SLP to function, it is necessary for the agent to join the UDP
multicast group to receive (amongst others) service request messages.
However, only the socket bound to the well-known port was joining the
multicast group, and if this was disabled then there would be no socket
bound to receive traffic from the multicast group, preventing discovery
from functioning.

This commit causes the ephemeral bound port to join the multicast group
if the well-known port is not being opened, allowing SLP discovery to
function in this case.

Related TFS: #87348